### PR TITLE
fix deprecated selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -2,7 +2,7 @@
 // Editor styles (background, gutter, guides)
 
 atom-text-editor,
-:host {
+atom-text-editor {
   color: @syntax-text-color;
   background-color: @syntax-background-color;
 

--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -12,12 +12,12 @@
 
 // Mixins -----------------------------------
 .punctuation-mixin(@color:@uno-4) {
-  .punctuation,
-  .bracket,
-  .brace {
+  .syntax--punctuation,
+  .syntax--bracket,
+  .syntax--brace {
     color: @color;
   }
-  .string .punctuation {
+  .syntax--string .syntax--punctuation {
     .duo-3();
   }
 }
@@ -27,38 +27,38 @@
 
 // this basically matches everything without a specific scope
 // so we put it first
-.meta {
+.syntax--meta {
   .uno-4();
 }
 
-.html.elements,
-.entity,
-.tag,
-.function-call {
+.syntax--html.syntax--elements,
+.syntax--entity,
+.syntax--tag,
+.syntax--function-call {
   .uno-1();
 }
 
-.variable,
-.character.escape,
-.html.attribute-name,
-.css.pseudo-element {
+.syntax--variable,
+.syntax--character.syntax--escape,
+.syntax--html.syntax--attribute-name,
+.syntax--css.syntax--pseudo-element {
   .uno-2();
 }
 
-.support {
+.syntax--support {
   .uno-3();
 }
 
 
 // Duo hue -----------------------------------
-.string,
-.constant,
-.storage.type {
+.syntax--string,
+.syntax--constant,
+.syntax--storage.syntax--type {
   .duo-1();
 }
 
-.keyword,
-.storage {
+.syntax--keyword,
+.syntax--storage {
   .duo-2();
 }
 
@@ -68,11 +68,11 @@
 
 
 // Comments -----------------------------------
-.comment {
+.syntax--comment {
   .duo-3();
 }
 
 
 // Text styles -----------------------------------
-.bold { font-weight: bold; }
-.italic { font-style: italic; }
+.syntax--bold { font-weight: bold; }
+.syntax--italic { font-style: italic; }

--- a/styles/languages/c.less
+++ b/styles/languages/c.less
@@ -1,10 +1,10 @@
-.c {
-  .parens,
-  .block {
+.syntax--c {
+  .syntax--parens,
+  .syntax--block {
     .uno-2();
     .punctuation-mixin();
   }
-  .comment {
+  .syntax--comment {
     .duo-3();
   }
 }

--- a/styles/languages/coffee.less
+++ b/styles/languages/coffee.less
@@ -1,7 +1,7 @@
 // Coffee
 
-.coffee {
-  &.source {
+.syntax--coffee {
+  &.syntax--source {
     .uno-3();
   }
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,12 +1,12 @@
 // CSS
 
-.css {
-  &.source {
+.syntax--css {
+  &.syntax--source {
     .uno-4();
   }
-  &.at-rule {
+  &.syntax--at-rule {
     .uno-1();
-    .keyword.punctuation {
+    .syntax--keyword.syntax--punctuation {
       color: inherit;
     }
   }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,32 +1,32 @@
 // GF MarkDown
 
-.gfm {
+.syntax--gfm {
   .uno-1();
   .punctuation-mixin();
 
-  &.markup,
-  & .link {
+  &.syntax--markup,
+  & .syntax--link {
     .uno-2();
   }
-  &.markup.raw,
-  &.markup .support {
+  &.syntax--markup.syntax--raw,
+  &.syntax--markup .syntax--support {
     .duo-3();
   }
 
-  &.variable,
-  &.entity {
+  &.syntax--variable,
+  &.syntax--entity {
     .duo-1();
   }
-  &.support  { .duo-2(); }
-  &.comment  { .duo-3(); }
+  &.syntax--support  { .duo-2(); }
+  &.syntax--comment  { .duo-3(); }
 
-  &.heading-1 { .duo-1(); }
-  &.heading-2 { .duo-2(); }
-  &.heading-3 { .uno-1(); }
-  &.heading-4 { .uno-2(); }
-  &.heading-5 { .uno-3(); }
-  &.heading-6 { .uno-4(); }
+  &.syntax--heading-1 { .duo-1(); }
+  &.syntax--heading-2 { .duo-2(); }
+  &.syntax--heading-3 { .uno-1(); }
+  &.syntax--heading-4 { .uno-2(); }
+  &.syntax--heading-5 { .uno-3(); }
+  &.syntax--heading-6 { .uno-4(); }
 
-  &.bold   { .bold(); }
-  &.italic { .italic(); }
+  &.syntax--bold   { .syntax--bold(); }
+  &.syntax--italic { .syntax--italic(); }
 }

--- a/styles/languages/haskell.less
+++ b/styles/languages/haskell.less
@@ -1,5 +1,5 @@
-.haskell {
-  &.source {
+.syntax--haskell {
+  &.syntax--source {
     .uno-2();
     .punctuation-mixin();
   }

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -1,13 +1,13 @@
 // HTML
 
-.html {
-  &.meta {
+.syntax--html {
+  &.syntax--meta {
     .uno-4();
   }
-  &.text {
+  &.syntax--text {
     .uno-3();
   }
-  .string .id {
+  .syntax--string .syntax--id {
     .duo-1();
   }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,9 +1,9 @@
-.java {
-  .method {
+.syntax--java {
+  .syntax--method {
     .uno-2();
     .punctuation-mixin();
   }
-  .dereference {
+  .syntax--dereference {
     .uno-4();
 
   }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,5 +1,5 @@
-.js {
-  &.source {
+.syntax--js {
+  &.syntax--source {
     .uno-2();
     .punctuation-mixin();
   }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,20 +1,20 @@
 // JSON
 
-.json {
-  .string {
+.syntax--json {
+  .syntax--string {
     .uno-2();
-    .punctuation {
+    .syntax--punctuation {
       .uno-4();
     }
   }
-  .value {
-    & > .string {
+  .syntax--value {
+    & > .syntax--string {
       .duo-1();
-      .punctuation {
+      .syntax--punctuation {
         .uno-4();
       }
     }
-    .constant {
+    .syntax--constant {
       .duo-2();
     }
   }

--- a/styles/languages/less.less
+++ b/styles/languages/less.less
@@ -1,10 +1,10 @@
 // Less
 
-.less {
-  &.variable:first-child {
+.syntax--less {
+  &.syntax--variable:first-child {
     .uno-1(); // stronger variable color when declaring
   }
-  .mixin {
+  .syntax--mixin {
     .duo-2();
   }
 }

--- a/styles/languages/mediawiki.less
+++ b/styles/languages/mediawiki.less
@@ -1,24 +1,24 @@
-.mediawiki {
+.syntax--mediawiki {
   .uno-1();
   .punctuation-mixin();
-  .wiki-link {
+  .syntax--wiki-link {
     .uno-2();
   }
-  .heading {
+  .syntax--heading {
     .duo-1();
   }
-  .function-call {
+  .syntax--function-call {
     .duo-2();
   }
-  .value {
+  .syntax--value {
     .duo-1();
   }
-  .fix_this_later {
+  .syntax--fix_this_later {
     .uno-2();
   }
-  .pipe,
-  .link,
-  .tag {
+  .syntax--pipe,
+  .syntax--link,
+  .syntax--tag {
     .uno-4();
   }
 }

--- a/styles/languages/php.less
+++ b/styles/languages/php.less
@@ -1,7 +1,7 @@
 // PHP
 
-.php {
-    .string-contents {
+.syntax--php {
+    .syntax--string-contents {
         .duo-1();
     }
 }

--- a/styles/languages/sass.less
+++ b/styles/languages/sass.less
@@ -1,14 +1,14 @@
 // SASS
 
-.sass {
-  .at-rule {
+.syntax--sass {
+  .syntax--at-rule {
     &,
-    > .punctuation {
+    > .syntax--punctuation {
       .uno-1();
     }
   }
-  .mixin > .variable,
-  .include > .variable {
+  .syntax--mixin > .syntax--variable,
+  .syntax--include > .syntax--variable {
     .duo-2();
   }
 }

--- a/styles/languages/scss.less
+++ b/styles/languages/scss.less
@@ -1,14 +1,14 @@
 // SCSS
 
-.scss {
-  .at-rule .at-rule {
+.syntax--scss {
+  .syntax--at-rule .syntax--at-rule {
     &,
-    > .punctuation{
+    > .syntax--punctuation{
       .uno-1();
     }
   }
-  .mixin + .function,
-  .include + .function {
+  .syntax--mixin + .syntax--function,
+  .syntax--include + .syntax--function {
     .duo-2();
   }
 }

--- a/styles/languages/stylus.less
+++ b/styles/languages/stylus.less
@@ -1,5 +1,5 @@
-.stylus {
-  .function .name {
+.syntax--stylus {
+  .syntax--function .syntax--name {
     .duo-2();
   }
 }

--- a/styles/languages/tex.less
+++ b/styles/languages/tex.less
@@ -1,8 +1,8 @@
-.tex {
-  .other {
+.syntax--tex {
+  .syntax--other {
     .duo-2();
   }
-  .reference {
+  .syntax--reference {
     .uno-2();
   }
 }

--- a/styles/languages/text.less
+++ b/styles/languages/text.less
@@ -1,5 +1,5 @@
 // Text
 
-.plain .text {
+.syntax--plain .syntax--text {
   .uno-1();
 }

--- a/styles/languages/yaml.less
+++ b/styles/languages/yaml.less
@@ -1,13 +1,13 @@
 // YAML
 
-.yaml {
-  .tag {
+.syntax--yaml {
+  .syntax--tag {
     .uno-2();
   }
-  .constant {
+  .syntax--constant {
     .duo-2();
   }
-  .punctuation {
+  .syntax--punctuation {
     .uno-4();
   }
 }


### PR DESCRIPTION
Updated `atom-text-editor` elements to no longer be encapsulated within a shadow DOM boundary. Removed all usage of `:host` and `::shadow` and prepended all syntax selectors with `syntax--`.